### PR TITLE
Image sizes and new parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ piuma_url("http://mypiumahost", "http://myimagehost/static/img/a.png", 200, 200,
 ```html
 {% load pypiuma_tags %}
 
-<img src="{% piuma 'http://myimagehost/static/img/a.png' width=200 %}">
+<img src="{% piuma 'http://myimagehost/static/img/a.png' width=200 convert_to="auto" %}">
 <img src="{% piuma_static 'img/mylogo.png' width=200 %}">
 ```
 
@@ -55,6 +55,39 @@ Default:  `/piuma/`
 Media rules for picture tags.
 
 Default: `(max-width: 576px),(max-width: 768px),(max-width: 992px),(max-width: 1366px)`
+
+## PIUMA_SIZES
+
+Fast configurations for your images. These can be handy if you want to define different
+sizes like `small`, `medium`, `full` to serve the best optimized version of the image for your needs.
+The `*` size, if defined, is applied to all images imported with a tag that do not specify a size.
+
+Default: `{}`
+
+Example:
+```python
+{
+  "*": {
+    "convert_to": "auto",
+    "quality": 80
+  },
+  "small": {
+    "width": 300,
+    "convert_to": "auto",
+    "quality": 80
+  },
+  "medium": {
+    "width": 500,
+    "convert_to": "auto",
+    "quality": 80
+  },
+  "large": {
+    "width": 1000,
+    "convert_to": "auto",
+    "quality": 80
+  }
+}
+```
 
 ## Run tests
 

--- a/pypiuma/core.py
+++ b/pypiuma/core.py
@@ -1,8 +1,13 @@
+import re
+
+exclude_regex = r".+\.(svg)$"
 
 def piuma_url(
     piuma_host, image_url, width=0, height=0,
     quality=100, adaptive_quality=False, convert_to="",
 ):
+    if re.match(exclude_regex, image_url):
+        return image_url
     piuma_host = piuma_host.rstrip('/')
     piuma_url = '{0}/{1}/{2}'.format(
         piuma_host,

--- a/pypiuma/core.py
+++ b/pypiuma/core.py
@@ -1,9 +1,16 @@
 
-def piuma_url(piuma_host, image_url, width=0, height=0, quality=100):
+def piuma_url(
+    piuma_host, image_url, width=0, height=0,
+    quality=100, adaptive_quality=False, convert_to="",
+):
     piuma_host = piuma_host.rstrip('/')
     piuma_url = '{0}/{1}/{2}'.format(
         piuma_host,
-        '{0}_{1}_{2}'.format(width, height, quality),
+        '{0}_{1}_{2}{3}{4}'.format(
+            width, height, quality,
+            "a" if adaptive_quality else "",
+            ":" + convert_to if convert_to else ""
+        ),
         image_url
     )
     return piuma_url

--- a/pypiuma/core.py
+++ b/pypiuma/core.py
@@ -1,13 +1,7 @@
-import re
-
-exclude_regex = r".+\.(svg)$"
-
 def piuma_url(
     piuma_host, image_url, width=0, height=0,
     quality=100, adaptive_quality=False, convert_to="",
 ):
-    if re.match(exclude_regex, image_url):
-        return image_url
     piuma_host = piuma_host.rstrip('/')
     piuma_url = '{0}/{1}/{2}'.format(
         piuma_host,

--- a/pypiuma/templatetags/pypiuma_tags.py
+++ b/pypiuma/templatetags/pypiuma_tags.py
@@ -23,7 +23,7 @@ def get_host_url(request):
 def piuma_size(size, **params):
     if getattr(settings, 'PIUMA_SIZES', {}).get(size):
         params = {**params, **settings.PIUMA_SIZES[size]}
-    elif not size and "*" in settings.PIUMA_SIZES:
+    elif not size and "*" in getattr(settings, 'PIUMA_SIZES', {}):
         params = {**params, **settings.PIUMA_SIZES["*"]}
 
     return params
@@ -58,22 +58,16 @@ def piuma_static(context, image_url, width=0, height=0, quality=100, adaptive_qu
 
 @register.simple_tag(takes_context=True)
 def piuma_img(context, image_url, width=0, height=0, quality=100, adaptive_quality=False, convert_to="", size="", **img_attributes):
-    generate_img = lambda url, attrs: mark_safe(
-        "<img src='{0}' {1}>".format(
-            image_url,
-            " ".join(['{0}="{1}"'.format(k, v) for k, v in img_attributes.items()]),
+    def generate_img(url, attrs):
+        return mark_safe(
+            "<img src='{0}' {1}>".format(
+                image_url,
+                " ".join(['{0}="{1}"'.format(k, v) for k, v in img_attributes.items()]),
+            )
         )
-    )
 
     if getattr(settings, "PIUMA_DISABLED", False):
         return generate_img(image_url, img_attributes)
-
-    if not image_url.startswith("http"):
-        image_url = (
-            get_host_url(context.get("request", None)).rstrip("/")
-            + "/"
-            + image_url.lstrip("/")
-        )
 
     params = piuma_size(
         size,

--- a/pypiuma/templatetags/pypiuma_tags.py
+++ b/pypiuma/templatetags/pypiuma_tags.py
@@ -1,3 +1,5 @@
+import re
+
 from django import template
 from django.conf import settings
 from django.templatetags.static import static
@@ -6,6 +8,7 @@ from django.utils.safestring import mark_safe
 from pypiuma import piuma_url
 
 
+exclude_regex = r".+\.(svg)$"
 register = template.Library()
 
 
@@ -36,7 +39,7 @@ def piuma_media_rules():
 
 @register.simple_tag(takes_context=True)
 def piuma(context, image_url, width=0, height=0, quality=100, adaptive_quality=False, convert_to="", size=""):
-    if getattr(settings, 'PIUMA_DISABLED', False):
+    if getattr(settings, 'PIUMA_DISABLED', False) or re.match(exclude_regex, image_url):
         return image_url
     if not image_url.startswith('http'):
         image_url = get_host_url(

--- a/pypiuma/templatetags/pypiuma_tags.py
+++ b/pypiuma/templatetags/pypiuma_tags.py
@@ -18,7 +18,7 @@ def get_host_url(request):
 
 
 @register.simple_tag(takes_context=True)
-def piuma(context, image_url, width=0, height=0, quality=100):
+def piuma(context, image_url, width=0, height=0, quality=100, adaptive_quality=False, convert_to=""):
     if getattr(settings, 'PIUMA_DISABLED', False):
         return image_url
     if not image_url.startswith('http'):
@@ -27,13 +27,13 @@ def piuma(context, image_url, width=0, height=0, quality=100):
         ).rstrip('/') + '/' + image_url.lstrip('/')
     return piuma_url(
         getattr(settings, 'PIUMA_HOST', '/piuma/'),
-        image_url, width, height, quality
+        image_url, width, height, quality, adaptive_quality, convert_to
     )
 
 
 @register.simple_tag(takes_context=True)
-def piuma_static(context, image_url, width=0, height=0, quality=100):
-    return piuma(context, static(image_url), width, height, quality)
+def piuma_static(context, image_url, width=0, height=0, quality=100, adaptive_quality=False, convert_to=""):
+    return piuma(context, static(image_url), width, height, quality, adaptive_quality, convert_to)
 
 
 def _generate_srcset(context, image_url, media_rule, size):
@@ -105,7 +105,6 @@ def piuma_picture(context, image_url, media_rules=None, picture_id="", img_id=""
 
 @register.simple_tag(takes_context=True)
 def piuma_picture_static(context, image_url, media_rules=None, picture_id="", img_id="", picture_class="", img_class="", img_alt=""):
-    print(static(image_url))
     return piuma_picture(
         context, static(image_url), media_rules,
         picture_id, img_id, picture_class,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,7 @@
 from django.test import RequestFactory
 
 from pypiuma import piuma_url
-from pypiuma.templatetags.pypiuma_tags import piuma, piuma_static, piuma_picture, piuma_picture_static
+from pypiuma.templatetags.pypiuma_tags import piuma, piuma_img, piuma_img_static, piuma_static, piuma_picture, piuma_picture_static
 
 
 def test_piuma_url(settings, client):
@@ -70,4 +70,25 @@ def test_piuma_picture(settings, client):
             context,
             "img/a.png"
         )
+    )
+
+def test_piuma_img(settings, client):
+    context = {
+        'request' : RequestFactory(HTTP_HOST='localhost:8000').get('/')
+    }
+
+    piuma_img(
+        context,
+        "http://localhost:8000/img/a.png"
+    )
+
+    piuma_img(
+        context,
+        "http://localhost:8000/img/a.png",
+        500
+    )
+
+    piuma_img_static(
+        context,
+        "img/a.png"
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,6 +9,10 @@ def test_piuma_url(settings, client):
     assert piumaurl == 'http://mypiumahost/200_200_80/http://myhost/static/img/a.png'
     piumaurl = piuma_url('http://mypiumahost', '/static/img/a.png', 200, 200, 80)
     assert piumaurl == 'http://mypiumahost/200_200_80//static/img/a.png'
+    piumaurl = piuma_url('http://mypiumahost', '/static/img/a.png', 200, 200, 80, adaptive_quality=True)
+    assert piumaurl == 'http://mypiumahost/200_200_80a//static/img/a.png'
+    piumaurl = piuma_url('http://mypiumahost', '/static/img/a.png', 200, 200, 80, adaptive_quality=True, convert_to="auto")
+    assert piumaurl == 'http://mypiumahost/200_200_80a:auto//static/img/a.png'
 
 
 def test_piuma_tag_without_request(settings, client):


### PR DESCRIPTION
Changes made in this PR:
- Image sizes: image can be imported in template specifying a certain size. This prevents browsers from loading high dimensions images in a context where those images are always displayed in low dimensions. An example of this feature can be the [Wordpress' images sizes](https://developer.wordpress.org/reference/functions/add_image_size/)
- Added convert_to and adaptive_quality parameters
- Added `piuma_img` and `piuma_img_static` which generates `<img>` tags with `src` and `srcset` attributes
- Refactored custom attributes handling for piuma pictures, now both `<picture>` and `<img>` tags can have whatever custom attributes they want